### PR TITLE
Make the bundle compatible with sylius typehint

### DIFF
--- a/src/Entity/CatalogPromotion.php
+++ b/src/Entity/CatalogPromotion.php
@@ -98,7 +98,7 @@ class CatalogPromotion implements CatalogPromotionInterface
     /**
      * {@inheritdoc}
      */
-    public function getCode()
+    public function getCode(): string
     {
         return $this->code;
     }
@@ -106,7 +106,7 @@ class CatalogPromotion implements CatalogPromotionInterface
     /**
      * {@inheritdoc}
      */
-    public function setCode($code)
+    public function setCode(?string $code): void
     {
         $this->code = $code;
     }


### PR DESCRIPTION
Fix the error:
Fatal error: Declaration of Urbanara\\CatalogPromotionPlugin\\Entity\\CatalogPromotion::getCode\(\) must be compatible with Sylius\\Component\\Resource\\Model\\CodeAwareInterface::getCode\(\): ?string in /var/www/vendor/urbanara/catalog-promotion-plugin/src/Entity/CatalogPromotion.php on line 12